### PR TITLE
fix(security): address medium priority security audit findings

### DIFF
--- a/GithubCopilotNotify/Info.plist
+++ b/GithubCopilotNotify/Info.plist
@@ -30,5 +30,10 @@
 	<string>Copyright © 2026 Unicorn Operations. All rights reserved.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
- Add certificate pinning for GitHub API requests via custom
  URLSessionDelegate that validates server trust for github.com
  domains
- Fix timer to only run when authenticated, preventing unnecessary
  network requests and battery drain when signed out
- Add explicit NSAppTransportSecurity configuration to Info.plist
  to document HTTPS-only security policy
