### PR TITLE
feat: add App Store release workflow and build script

### DIFF
--- a/.github/workflows/appstore-release.yml
+++ b/.github/workflows/appstore-release.yml
@@ -1,0 +1,357 @@
+name: App Store Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., 1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+  packages: read
+
+jobs:
+  appstore-build:
+    name: Build for App Store
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Show build environment
+        run: |
+          echo "Xcode version:"
+          xcodebuild -version
+          echo ""
+          echo "Swift version:"
+          swift --version
+          echo ""
+          echo "macOS version:"
+          sw_vers
+
+      - name: Set version
+        id: version
+        run: |
+          VERSION="${{ inputs.version }}"
+          # Remove 'v' prefix if present
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "build_number=${{ github.run_number }}" >> $GITHUB_OUTPUT
+          echo "Building version: $VERSION (build ${{ github.run_number }})"
+
+      - name: Validate App Store entitlements
+        run: |
+          echo "Validating App Store entitlements for sandboxing compliance..."
+          ENTITLEMENTS_FILE="GithubCopilotNotify/GithubCopilotNotify.AppStore.entitlements"
+
+          if [ ! -f "$ENTITLEMENTS_FILE" ]; then
+            echo "Error: Entitlements file not found: $ENTITLEMENTS_FILE"
+            exit 1
+          fi
+
+          # Check that app sandbox is enabled
+          if ! /usr/libexec/PlistBuddy -c "Print :com.apple.security.app-sandbox" "$ENTITLEMENTS_FILE" 2>/dev/null | grep -q "true"; then
+            echo "Error: App sandbox must be enabled (com.apple.security.app-sandbox = true)"
+            exit 1
+          fi
+          echo "✓ App sandbox is enabled"
+
+          # Check for any entitlements set to false (which causes App Store rejection)
+          # Apple requires that if you don't need an entitlement, you omit it entirely
+          # Setting an entitlement to false is considered an invalid value
+          INVALID_ENTITLEMENTS=()
+
+          # List of entitlements that must not be set to false
+          ENTITLEMENTS_TO_CHECK=(
+            "com.apple.security.files.downloads.read-write"
+            "com.apple.security.files.user-selected.read-only"
+            "com.apple.security.files.user-selected.read-write"
+            "com.apple.security.network.server"
+            "com.apple.security.network.client"
+            "com.apple.security.files.bookmarks.app-scope"
+            "com.apple.security.files.bookmarks.document-scope"
+          )
+
+          for entitlement in "${ENTITLEMENTS_TO_CHECK[@]}"; do
+            VALUE=$(/usr/libexec/PlistBuddy -c "Print :$entitlement" "$ENTITLEMENTS_FILE" 2>/dev/null || echo "NOT_PRESENT")
+            if [ "$VALUE" = "false" ]; then
+              INVALID_ENTITLEMENTS+=("$entitlement")
+              echo "✗ Invalid: $entitlement is set to false (should be omitted if not needed)"
+            elif [ "$VALUE" = "NOT_PRESENT" ]; then
+              echo "✓ $entitlement is correctly omitted"
+            else
+              echo "✓ $entitlement = $VALUE"
+            fi
+          done
+
+          if [ ${#INVALID_ENTITLEMENTS[@]} -gt 0 ]; then
+            echo ""
+            echo "Error: Found ${#INVALID_ENTITLEMENTS[@]} entitlement(s) with invalid false values"
+            echo "App Store requires entitlements to be omitted if not needed, not set to false"
+            echo ""
+            echo "Invalid entitlements:"
+            for e in "${INVALID_ENTITLEMENTS[@]}"; do
+              echo "  - $e"
+            done
+            exit 1
+          fi
+
+          echo ""
+          echo "✅ All entitlements are valid for App Store submission"
+
+      - name: Setup App Store code signing
+        env:
+          APP_CERTIFICATE_BASE64: ${{ secrets.APPSTORE_CERTIFICATE_BASE64 }}
+          INSTALLER_CERTIFICATE_BASE64: ${{ secrets.APPSTORE_INSTALLER_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPSTORE_CERTIFICATE_PASSWORD }}
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.APPSTORE_PROVISIONING_PROFILE_BASE64 }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          # Create a temporary keychain
+          KEYCHAIN_NAME="appstore.keychain"
+          KEYCHAIN_PASSWORD="temporary_password_$(uuidgen)"
+          KEYCHAIN_PATH="$HOME/Library/Keychains/$KEYCHAIN_NAME-db"
+
+          echo "Creating temporary keychain..."
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security set-keychain-settings "$KEYCHAIN_NAME"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security list-keychains -d user -s "$KEYCHAIN_NAME" $(security list-keychains -d user | sed s/\"//g)
+
+          # Import App Store application certificate
+          echo "Importing App Store application certificate..."
+          APP_CERT_PATH=$RUNNER_TEMP/appstore_app.p12
+          echo "$APP_CERTIFICATE_BASE64" | base64 --decode > "$APP_CERT_PATH"
+
+          security import "$APP_CERT_PATH" \
+            -P "$CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_NAME" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+
+          # Import App Store installer certificate
+          echo "Importing App Store installer certificate..."
+          INSTALLER_CERT_PATH=$RUNNER_TEMP/appstore_installer.p12
+          echo "$INSTALLER_CERTIFICATE_BASE64" | base64 --decode > "$INSTALLER_CERT_PATH"
+
+          security import "$INSTALLER_CERT_PATH" \
+            -P "$CERTIFICATE_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_NAME" \
+            -T /usr/bin/productbuild \
+            -T /usr/bin/security
+
+          # Set partition list
+          security set-key-partition-list -S apple-tool:,apple:,codesign:,productbuild: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+
+          # Install provisioning profile
+          echo "Installing provisioning profile..."
+          PROFILE_PATH=$RUNNER_TEMP/appstore.provisionprofile
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< $(/usr/bin/security cms -D -i "$PROFILE_PATH"))
+          echo "Provisioning profile UUID: $PROFILE_UUID"
+          cp "$PROFILE_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/"$PROFILE_UUID".provisionprofile
+
+          # Verify certificates
+          echo "Installed codesigning certificates:"
+          security find-identity -v -p codesigning "$KEYCHAIN_NAME"
+
+          echo ""
+          echo "All installed identities:"
+          security find-identity -v "$KEYCHAIN_NAME"
+
+          # Extract identities
+          # Application certificate uses codesigning policy
+          APP_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_NAME" | grep "3rd Party Mac Developer Application" | head -1 | sed -n 's/.*"\(.*\)"/\1/p')
+
+          # Installer certificate is NOT a codesigning cert - search all identities
+          INSTALLER_IDENTITY=$(security find-identity -v "$KEYCHAIN_NAME" | grep "3rd Party Mac Developer Installer" | head -1 | sed -n 's/.*"\(.*\)"/\1/p')
+
+          # Also try "Mac Installer Distribution" (newer naming)
+          if [ -z "$INSTALLER_IDENTITY" ]; then
+            INSTALLER_IDENTITY=$(security find-identity -v "$KEYCHAIN_NAME" | grep "Mac Installer Distribution" | head -1 | sed -n 's/.*"\(.*\)"/\1/p')
+          fi
+
+          if [ -z "$APP_IDENTITY" ]; then
+            echo "Error: App Store Application certificate not found"
+            exit 1
+          fi
+
+          if [ -z "$INSTALLER_IDENTITY" ]; then
+            echo "Error: App Store Installer certificate not found"
+            echo "Expected certificate named '3rd Party Mac Developer Installer' or 'Mac Installer Distribution'"
+            exit 1
+          fi
+
+          echo "APP_SIGNING_IDENTITY=$APP_IDENTITY" >> $GITHUB_ENV
+          echo "INSTALLER_SIGNING_IDENTITY=$INSTALLER_IDENTITY" >> $GITHUB_ENV
+          echo "KEYCHAIN_NAME=$KEYCHAIN_NAME" >> $GITHUB_ENV
+          echo "KEYCHAIN_PASSWORD=$KEYCHAIN_PASSWORD" >> $GITHUB_ENV
+
+          echo "✅ App Store code signing certificates installed"
+
+      - name: Build and archive for App Store
+        run: |
+          echo "Creating archive for App Store..."
+
+          # Unlock keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+
+          # Clean build directory
+          rm -rf build/AppStore
+
+          # Archive
+          # Use github.run_number as the build number to ensure it's unique and incrementing
+          xcodebuild archive \
+            -project GithubCopilotNotify.xcodeproj \
+            -scheme GithubCopilotNotify \
+            -archivePath build/AppStore/GithubCopilotNotify.xcarchive \
+            -configuration Release \
+            CURRENT_PROJECT_VERSION=${{ github.run_number }} \
+            MARKETING_VERSION=${{ steps.version.outputs.version }} \
+            CODE_SIGN_IDENTITY="$APP_SIGNING_IDENTITY" \
+            CODE_SIGN_STYLE=Manual \
+            PROVISIONING_PROFILE_SPECIFIER="GithubCopilotNotify App Store" \
+            CODE_SIGN_ENTITLEMENTS="GithubCopilotNotify/GithubCopilotNotify.AppStore.entitlements" \
+            ENABLE_HARDENED_RUNTIME=NO \
+            OTHER_CODE_SIGN_FLAGS="--keychain $KEYCHAIN_NAME --timestamp"
+
+          if [ ! -d "build/AppStore/GithubCopilotNotify.xcarchive" ]; then
+            echo "Error: Archive creation failed"
+            exit 1
+          fi
+
+          echo "✅ Archive created successfully"
+
+      - name: Export for App Store
+        env:
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          BUNDLE_ID: ${{ vars.BUNDLE_ID || 'ie.unicornops.githubcopilotnotify' }}
+        run: |
+          echo "Exporting for App Store..."
+
+          # Create export options plist
+          cat > build/AppStore/ExportOptions.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store-connect</string>
+              <key>teamID</key>
+              <string>$TEAM_ID</string>
+              <key>uploadSymbols</key>
+              <true/>
+              <key>signingCertificate</key>
+              <string>3rd Party Mac Developer Application</string>
+              <key>installerSigningCertificate</key>
+              <string>3rd Party Mac Developer Installer</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>$BUNDLE_ID</key>
+                  <string>GithubCopilotNotify App Store</string>
+              </dict>
+          </dict>
+          </plist>
+          EOF
+
+          # Export archive
+          xcodebuild -exportArchive \
+            -archivePath build/AppStore/GithubCopilotNotify.xcarchive \
+            -exportPath build/AppStore/export \
+            -exportOptionsPlist build/AppStore/ExportOptions.plist
+
+          if [ ! -f "build/AppStore/export/GithubCopilotNotify.pkg" ]; then
+            echo "Error: Export failed - no PKG created"
+            exit 1
+          fi
+
+          # Move PKG to expected location
+          mv build/AppStore/export/GithubCopilotNotify.pkg build/AppStore/GithubCopilotNotify.pkg
+
+          echo "✅ Package exported successfully"
+
+      - name: Verify package
+        run: |
+          echo "Verifying package signature..."
+          pkgutil --check-signature build/AppStore/GithubCopilotNotify.pkg
+          echo "✅ Package signature verified"
+
+      - name: Upload to App Store Connect
+        env:
+          APPLE_USERNAME: ${{ secrets.APPLE_DEVELOPER_ID }}
+          APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+          TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          echo "Uploading to App Store Connect..."
+          echo "This may take several minutes..."
+
+          # Use altool for upload with username/password authentication
+          # -u: Apple ID (email) for authentication
+          # -p: App-specific password (use @env: prefix to read from env var securely)
+          xcrun altool --upload-app \
+            -f build/AppStore/GithubCopilotNotify.pkg \
+            -t macos \
+            -u "$APPLE_USERNAME" \
+            -p "@env:APP_SPECIFIC_PASSWORD" \
+            --team-id "$TEAM_ID" \
+            --verbose
+
+          echo "✅ Upload complete!"
+          echo ""
+          echo "Next steps:"
+          echo "1. Go to App Store Connect: https://appstoreconnect.apple.com"
+          echo "2. Navigate to your app"
+          echo "3. Add build to your release"
+          echo "4. Submit for review"
+
+      - name: Cleanup certificates
+        if: always()
+        run: |
+          echo "Cleaning up keychain..."
+          if [ -n "$KEYCHAIN_NAME" ]; then
+            security delete-keychain "$KEYCHAIN_NAME" 2>/dev/null || true
+          fi
+          echo "Certificate cleanup complete"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: appstore-build-${{ steps.version.outputs.version }}
+          path: |
+            build/AppStore/GithubCopilotNotify.pkg
+            build/AppStore/GithubCopilotNotify.xcarchive
+          retention-days: 30
+
+      - name: Build summary
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BUILD_NUMBER="${{ steps.version.outputs.build_number }}"
+
+          echo "## App Store Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: $VERSION (build $BUILD_NUMBER)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Package**: GithubCopilotNotify.pkg" >> $GITHUB_STEP_SUMMARY
+          echo "- **Xcode**: $(xcodebuild -version | head -n 1)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Swift**: $(swift --version | head -n 1)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "1. Go to [App Store Connect](https://appstoreconnect.apple.com)" >> $GITHUB_STEP_SUMMARY
+          echo "2. Select your app" >> $GITHUB_STEP_SUMMARY
+          echo "3. Add the build to your release" >> $GITHUB_STEP_SUMMARY
+          echo "4. Complete app information and screenshots" >> $GITHUB_STEP_SUMMARY
+          echo "5. Submit for review" >> $GITHUB_STEP_SUMMARY

--- a/GithubCopilotNotify/GithubCopilotNotify.AppStore.entitlements
+++ b/GithubCopilotNotify/GithubCopilotNotify.AppStore.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/build-appstore.sh
+++ b/build-appstore.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+#
+# Build script for Mac App Store distribution
+# This creates an archive suitable for upload to App Store Connect
+#
+# Usage:
+#   ./build-appstore.sh [version]
+#
+# Requirements:
+#   - "3rd Party Mac Developer Application" certificate installed
+#   - "3rd Party Mac Developer Installer" certificate installed
+#   - Provisioning profile for the app
+#   - Xcode command line tools
+#
+# Output:
+#   - build/AppStore/GithubCopilotNotify.xcarchive - Archive for App Store
+#   - build/AppStore/GithubCopilotNotify.pkg - Signed package ready for upload
+#
+
+set -e  # Exit on error
+set -u  # Exit on undefined variable
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Configuration
+SCHEME="GithubCopilotNotify"
+PROJECT="GithubCopilotNotify.xcodeproj"
+BUNDLE_ID="ie.unicornops.githubcopilotnotify"
+BUILD_DIR="build/AppStore"
+ARCHIVE_PATH="${BUILD_DIR}/${SCHEME}.xcarchive"
+EXPORT_PATH="${BUILD_DIR}/export"
+PKG_PATH="${BUILD_DIR}/${SCHEME}.pkg"
+
+echo -e "${GREEN}=== Mac App Store Build Script ===${NC}"
+echo ""
+
+# Verify we have the required certificates
+echo "Checking for required certificates..."
+if ! security find-identity -v -p codesigning | grep -q "3rd Party Mac Developer Application"; then
+    echo -e "${RED}Error: '3rd Party Mac Developer Application' certificate not found${NC}"
+    echo "You need to download this certificate from Apple Developer Portal"
+    echo "and install it in your keychain."
+    exit 1
+fi
+
+if ! security find-identity -v | grep -q "3rd Party Mac Developer Installer"; then
+    echo -e "${RED}Error: '3rd Party Mac Developer Installer' certificate not found${NC}"
+    echo "You need to download this certificate from Apple Developer Portal"
+    echo "and install it in your keychain."
+    exit 1
+fi
+
+echo -e "${GREEN}Found required certificates${NC}"
+echo ""
+
+# Extract certificate identities
+APP_IDENTITY=$(security find-identity -v -p codesigning | grep "3rd Party Mac Developer Application" | head -1 | sed -n 's/.*"\(.*\)"/\1/p')
+INSTALLER_IDENTITY=$(security find-identity -v | grep "3rd Party Mac Developer Installer" | head -1 | sed -n 's/.*"\(.*\)"/\1/p')
+
+echo "Using certificates:"
+echo "  App: $APP_IDENTITY"
+echo "  Installer: $INSTALLER_IDENTITY"
+echo ""
+
+# Clean build directory
+echo "Cleaning build directory..."
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}"
+echo ""
+
+# Archive the app
+echo "Creating archive for App Store..."
+echo "This may take a few minutes..."
+echo ""
+
+xcodebuild archive \
+    -project "${PROJECT}" \
+    -scheme "${SCHEME}" \
+    -archivePath "${ARCHIVE_PATH}" \
+    -configuration Release \
+    CODE_SIGN_IDENTITY="${APP_IDENTITY}" \
+    CODE_SIGN_STYLE=Manual \
+    PROVISIONING_PROFILE_SPECIFIER="GithubCopilotNotify App Store" \
+    CODE_SIGN_ENTITLEMENTS="GithubCopilotNotify/GithubCopilotNotify.AppStore.entitlements" \
+    ENABLE_HARDENED_RUNTIME=NO \
+    | grep -v "^$" || true  # Filter empty lines, don't fail on grep
+
+if [ ! -d "${ARCHIVE_PATH}" ]; then
+    echo -e "${RED}Error: Archive creation failed${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}Archive created successfully${NC}"
+echo ""
+
+# Export for App Store
+echo "Exporting for App Store..."
+echo ""
+
+# Create export options plist
+cat > "${BUILD_DIR}/ExportOptions.plist" << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>teamID</key>
+    <string>YOUR_TEAM_ID</string>
+    <key>uploadSymbols</key>
+    <true/>
+    <key>uploadBitcode</key>
+    <false/>
+</dict>
+</plist>
+EOF
+
+xcodebuild -exportArchive \
+    -archivePath "${ARCHIVE_PATH}" \
+    -exportPath "${EXPORT_PATH}" \
+    -exportOptionsPlist "${BUILD_DIR}/ExportOptions.plist" \
+    | grep -v "^$" || true
+
+if [ ! -f "${EXPORT_PATH}/${SCHEME}.pkg" ]; then
+    echo -e "${RED}Error: Export failed - no PKG created${NC}"
+    echo "Check ExportOptions.plist and ensure your team ID is correct"
+    exit 1
+fi
+
+# Move PKG to build directory
+mv "${EXPORT_PATH}/${SCHEME}.pkg" "${PKG_PATH}"
+
+echo -e "${GREEN}Package created successfully${NC}"
+echo ""
+
+# Get app info from archive
+echo "=== Build Information ==="
+APP_PATH="${ARCHIVE_PATH}/Products/Applications/${SCHEME}.app"
+PLIST_PATH="${APP_PATH}/Contents/Info.plist"
+
+if [ -f "${PLIST_PATH}" ]; then
+    BUNDLE_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PLIST_PATH")
+    BUNDLE_BUILD=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$PLIST_PATH")
+
+    echo "Bundle ID: ${BUNDLE_ID}"
+    echo "Version: ${BUNDLE_VERSION}"
+    echo "Build: ${BUNDLE_BUILD}"
+    echo ""
+fi
+
+# Verify package signature
+echo "Verifying package signature..."
+pkgutil --check-signature "${PKG_PATH}"
+echo ""
+
+echo -e "${GREEN}=== Build Complete ===${NC}"
+echo ""
+echo "Archive: ${ARCHIVE_PATH}"
+echo "Package: ${PKG_PATH}"
+echo ""
+echo "Next steps:"
+echo "1. Validate the package:"
+echo "   xcrun altool --validate-app -f ${PKG_PATH} -t macos --apiKey YOUR_KEY --apiIssuer YOUR_ISSUER"
+echo ""
+echo "2. Upload to App Store Connect:"
+echo "   xcrun altool --upload-app -f ${PKG_PATH} -t macos --apiKey YOUR_KEY --apiIssuer YOUR_ISSUER"
+echo ""
+echo "   OR use Transporter app (recommended)"
+echo ""
+echo "3. Go to App Store Connect to complete submission"
+echo ""


### PR DESCRIPTION
- Add GitHub Actions workflow for App Store releases
- Add local build script for App Store distribution
- Create App Store entitlements file with sandbox and network
  permissions

Adapted from oncallnotify project with project-specific naming
and bundle identifiers.
