### PR TITLE
fix: Post login crash

### DIFF
--- a/GithubCopilotNotify/AppDelegate.swift
+++ b/GithubCopilotNotify/AppDelegate.swift
@@ -151,12 +151,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             // Cookies are automatically saved to Keychain by GitHubWebAuthClient
             // Restart the timer and fetch usage
-            startUpdating()
+            await MainActor.run {
+                self.startUpdating()
+            }
         } catch {
             print("Web auth error: \(error)")
             updateStatusBar(text: "Sign In Failed")
-
-            DispatchQueue.main.async {
+            await MainActor.run {
                 self.showError(message: "Failed to sign in: \(error.localizedDescription)")
             }
         }

--- a/GithubCopilotNotify/CopilotSessionAPI.swift
+++ b/GithubCopilotNotify/CopilotSessionAPI.swift
@@ -1,4 +1,6 @@
 import Foundation
+import Network
+import CryptoKit
 
 // Copilot entitlement response structure
 struct CopilotEntitlement: Codable {
@@ -53,63 +55,164 @@ struct CopilotTrial: Codable {
     let eligible: Bool
 }
 
-// MARK: - Certificate Pinning Session Delegate
+enum CertificatePinningError: Error, LocalizedError {
+    case failedToConnect
+    case trustEvaluationFailed
+    case pinMismatch
+    case connectionCancelled
 
-class GitHubPinnedSessionDelegate: NSObject, URLSessionDelegate {
-    // GitHub's public key pins (SHA-256 hashes of the public key info)
-    // These are the SPKI hashes for GitHub's certificates
-    private let pinnedHosts = ["github.com"]
+    var errorDescription: String? {
+        switch self {
+        case .failedToConnect:
+            return "Failed to establish TLS connection for pin validation"
+        case .trustEvaluationFailed:
+            return "TLS trust evaluation failed"
+        case .pinMismatch:
+            return "Certificate pin validation failed"
+        case .connectionCancelled:
+            return "TLS connection was cancelled"
+        }
+    }
+}
 
-    func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge,
-                    completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
-              let serverTrust = challenge.protectionSpace.serverTrust else {
-            completionHandler(.performDefaultHandling, nil)
+final class GitHubCertificatePinner {
+    // Historical GitHub HPKP pins (SHA-256 of SPKI); includes primary + backup.
+    // Keep at least two pins to support rotations.
+    private let allowedSPKISHA256Base64: Set<String> = [
+        "WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=", // pragma: allowlist secret
+        "JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=" // pragma: allowlist secret
+    ]
+
+    private let host = "github.com"
+    private let validationTTL: TimeInterval = 600 // 10 minutes
+    private let stateQueue = DispatchQueue(label: "ie.unicornops.githubcopilotnotify.pinning.state")
+    private var lastValidationAt: Date?
+
+    private final class CompletionGate: @unchecked Sendable {
+        private let lock = NSLock()
+        private var isCompleted = false
+
+        func markIfNeeded() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !isCompleted else { return false }
+            isCompleted = true
+            return true
+        }
+    }
+
+    func validateIfNeeded() async throws {
+        if isValidationFresh() {
             return
         }
 
-        let host = challenge.protectionSpace.host
+        try await validateTLSConnection()
+        markValidationSuccess()
+    }
 
-        // Only apply pinning for GitHub domains
-        guard pinnedHosts.contains(host) || host.hasSuffix(".github.com") else {
-            completionHandler(.performDefaultHandling, nil)
-            return
+    private func isValidationFresh() -> Bool {
+        stateQueue.sync {
+            guard let lastValidationAt else { return false }
+            return Date().timeIntervalSince(lastValidationAt) < validationTTL
         }
+    }
 
-        // Evaluate the server trust using system's default policy
+    private func markValidationSuccess() {
+        stateQueue.sync {
+            lastValidationAt = Date()
+        }
+    }
+
+    private func validateTLSConnection() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let completionQueue = DispatchQueue(label: "ie.unicornops.githubcopilotnotify.pinning.verify")
+            let tlsOptions = NWProtocolTLS.Options()
+            let secOptions = tlsOptions.securityProtocolOptions
+
+            sec_protocol_options_set_verify_block(secOptions, { [weak self] _, trust, complete in
+                guard let self else {
+                    complete(false)
+                    return
+                }
+                let trustRef = sec_trust_copy_ref(trust).takeRetainedValue()
+
+                if self.isTrustValidAndPinned(trust: trustRef) {
+                    complete(true)
+                } else {
+                    complete(false)
+                }
+            }, completionQueue)
+
+            let parameters = NWParameters(tls: tlsOptions, tcp: NWProtocolTCP.Options())
+            let connection = NWConnection(host: NWEndpoint.Host(host), port: 443, using: parameters)
+            let completionGate = CompletionGate()
+
+            @Sendable func completeOnce(_ result: Result<Void, Error>) {
+                guard completionGate.markIfNeeded() else { return }
+                connection.cancel()
+                continuation.resume(with: result)
+            }
+
+            connection.stateUpdateHandler = { state in
+                switch state {
+                case .ready:
+                    completeOnce(.success(()))
+                case .failed(let error):
+                    #if DEBUG
+                    print("Pinning connection failed: \(error)")
+                    #endif
+                    completeOnce(.failure(CertificatePinningError.failedToConnect))
+                case .cancelled:
+                    completeOnce(.failure(CertificatePinningError.connectionCancelled))
+                default:
+                    break
+                }
+            }
+
+            connection.start(queue: completionQueue)
+        }
+    }
+
+    private func isTrustValidAndPinned(trust: SecTrust) -> Bool {
+        let sslPolicy = SecPolicyCreateSSL(true, host as CFString)
+        SecTrustSetPolicies(trust, sslPolicy)
+
         var error: CFError?
-        let isValid = SecTrustEvaluateWithError(serverTrust, &error)
-
-        if isValid {
-            // Trust is valid according to system CA - accept the connection
-            // Note: For production apps requiring higher security, you would compare
-            // the certificate's public key hash against known GitHub certificate pins.
-            // However, GitHub rotates certificates, so we trust the system CA validation.
-            let credential = URLCredential(trust: serverTrust)
-            completionHandler(.useCredential, credential)
-        } else {
+        guard SecTrustEvaluateWithError(trust, &error) else {
             #if DEBUG
-            print("Certificate validation failed for \(host): \(String(describing: error))")
+            print("Pinning trust evaluation failed: \(String(describing: error))")
             #endif
-            completionHandler(.cancelAuthenticationChallenge, nil)
+            return false
         }
+
+        let chain = (SecTrustCopyCertificateChain(trust) as? [SecCertificate]) ?? []
+        guard !chain.isEmpty else { return false }
+
+        for certificate in chain {
+            guard let key = SecCertificateCopyKey(certificate),
+                  let keyData = SecKeyCopyExternalRepresentation(key, nil) as Data?
+            else {
+                continue
+            }
+
+            let hash = Data(SHA256.hash(data: keyData)).base64EncodedString()
+            if allowedSPKISHA256Base64.contains(hash) {
+                return true
+            }
+        }
+
+        return false
     }
 }
 
 class CopilotSessionAPIClient {
     private let keychainStorage: KeychainCookieStorage
     private let entitlementURL = "https://github.com/github-copilot/chat/entitlement"
-    private let pinnedSession: URLSession
-    private let sessionDelegate: GitHubPinnedSessionDelegate
+    private let certificatePinner: GitHubCertificatePinner
 
     init() {
         self.keychainStorage = KeychainCookieStorage.shared
-        self.sessionDelegate = GitHubPinnedSessionDelegate()
-        self.pinnedSession = URLSession(
-            configuration: .default,
-            delegate: sessionDelegate,
-            delegateQueue: nil
-        )
+        self.certificatePinner = GitHubCertificatePinner()
     }
 
     private func createEntitlementRequest() throws -> URLRequest {
@@ -188,8 +291,9 @@ class CopilotSessionAPIClient {
     }
 
     func fetchUsagePercentage() async throws -> Double {
+        try await certificatePinner.validateIfNeeded()
         let request = try createEntitlementRequest()
-        let (data, response) = try await pinnedSession.data(for: request)
+        let (data, response) = try await URLSession.shared.data(for: request)
         try handleResponse(response, data: data)
         return try parseEntitlement(from: data)
     }

--- a/GithubCopilotNotify/GitHubWebAuthClient.swift
+++ b/GithubCopilotNotify/GitHubWebAuthClient.swift
@@ -6,6 +6,7 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
     private var window: NSWindow?
     private var webView: WKWebView?
     private var continuation: CheckedContinuation<[String: String], Error>?
+    private var didCompleteAuthentication = false
 
     enum AuthError: Error, LocalizedError {
         case userCancelled
@@ -28,6 +29,7 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
     func authenticate() async throws -> [String: String] {
         return try await withCheckedThrowingContinuation { continuation in
             self.continuation = continuation
+            self.didCompleteAuthentication = false
             self.showLoginWindow()
         }
     }
@@ -121,9 +123,7 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
     private func extractCookies() {
         guard let webView = webView else {
             DispatchQueue.main.async { [weak self] in
-                self?.continuation?.resume(throwing: AuthError.cookieExtractionFailed)
-                self?.continuation = nil
-                self?.closeWindowSync()
+                self?.completeAuthentication(with: .failure(AuthError.cookieExtractionFailed))
             }
             return
         }
@@ -153,9 +153,7 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
                 self.saveCookiesToPersistentStore(cookies: cookies)
 
                 DispatchQueue.main.async {
-                    self.continuation?.resume(returning: cookieDict)
-                    self.continuation = nil
-                    self.closeWindowSync()
+                    self.completeAuthentication(with: .success(cookieDict))
                 }
             } else {
                 #if DEBUG
@@ -187,14 +185,26 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
         window = nil
         webView = nil
     }
+
+    private func completeAuthentication(with result: Result<[String: String], Error>) {
+        assert(Thread.isMainThread, "completeAuthentication must be called from main thread")
+        guard !didCompleteAuthentication else { return }
+        didCompleteAuthentication = true
+
+        switch result {
+        case .success(let cookies):
+            continuation?.resume(returning: cookies)
+        case .failure(let error):
+            continuation?.resume(throwing: error)
+        }
+        continuation = nil
+        closeWindowSync()
+    }
 }
 
 // Window delegate to handle window closure
 extension GitHubWebAuthClient: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
-        if continuation != nil {
-            continuation?.resume(throwing: AuthError.userCancelled)
-            continuation = nil
-        }
+        completeAuthentication(with: .failure(AuthError.userCancelled))
     }
 }


### PR DESCRIPTION
Implement GitHubCertificatePinner to validate TLS connections using
historical SPKI pins before API calls. Replace custom URLSession
delegate
with explicit pinning step in CopilotSessionAPIClient. Refactor
GitHubWebAuthClient to ensure authentication continuations are completed
safely and only once.
