### PR TITLE
fix: Update certificate pinning and improve WebAuth window handling

### DIFF
--- a/GithubCopilotNotify/AppDelegate.swift
+++ b/GithubCopilotNotify/AppDelegate.swift
@@ -90,6 +90,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             #if DEBUG
             print("API error (\(error.code.rawValue)): \(error.localizedDescription)")
             #endif
+        } catch is CertificatePinningError {
+            updateStatusBar(text: "Security Error")
+            #if DEBUG
+            print("Certificate pinning validation failed")
+            #endif
         } catch {
             // Handle non-URLError cases (e.g., JSON decoding errors)
             updateStatusBar(text: "Error")

--- a/GithubCopilotNotify/CopilotSessionAPI.swift
+++ b/GithubCopilotNotify/CopilotSessionAPI.swift
@@ -76,11 +76,15 @@ enum CertificatePinningError: Error, LocalizedError {
 }
 
 final class GitHubCertificatePinner {
-    // Historical GitHub HPKP pins (SHA-256 of SPKI); includes primary + backup.
-    // Keep at least two pins to support rotations.
+    // GitHub certificate chain SPKI pins (SHA-256, base64) captured from live chain.
+    // Includes leaf + intermediate + root; any chain key match is accepted.
     private let allowedSPKISHA256Base64: Set<String> = [
-        "WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=", // pragma: allowlist secret
-        "JbQbUG5JMJUoI6brnx0x3vZF6jilxsapbXGVfjhN8Fg=" // pragma: allowlist secret
+        // github.com leaf key (2026-03-01)
+        "HKlrX9VOPI9IC6usNi99M9wgWigfPdJmPCF7IPg0BVE=", // pragma: allowlist secret
+        // Sectigo Public Server Authentication CA DV E36
+        "ZSagvDzjltLkewXEBuDxIzpW/dpVw1Juvvmd0hhkzdY=", // pragma: allowlist secret
+        // Sectigo Public Server Authentication Root E46
+        "sLVjNUaFYfW7n6EtgBeEpjOlcnBdNPMrZDRF36iwBdE=" // pragma: allowlist secret
     ]
 
     private let host = "github.com"

--- a/GithubCopilotNotify/GitHubWebAuthClient.swift
+++ b/GithubCopilotNotify/GitHubWebAuthClient.swift
@@ -7,6 +7,7 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
     private var webView: WKWebView?
     private var continuation: CheckedContinuation<[String: String], Error>?
     private var didCompleteAuthentication = false
+    private var isWindowClosing = false
 
     enum AuthError: Error, LocalizedError {
         case userCancelled
@@ -36,6 +37,8 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
 
     @MainActor
     private func showLoginWindow() {
+        isWindowClosing = false
+
         // Create WebView configuration
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = .nonPersistent() // Use fresh session each time
@@ -56,6 +59,7 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
             backing: .buffered,
             defer: false
         )
+        window.isReleasedWhenClosed = false
         window.title = "Sign in to GitHub"
         window.contentView = webView
         window.minSize = NSSize(width: 800, height: 600)  // Minimum size for usability
@@ -181,12 +185,34 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
     private func closeWindowSync() {
         // Must be called from main thread
         assert(Thread.isMainThread, "closeWindowSync must be called from main thread")
-        window?.close()
+        guard let window else {
+            cleanupWindowReferences()
+            return
+        }
+
+        if isWindowClosing {
+            cleanupWindowReferences()
+            return
+        }
+
+        isWindowClosing = true
+        window.delegate = nil
+        window.orderOut(nil)
+        window.close()
+        cleanupWindowReferences()
+    }
+
+    private func cleanupWindowReferences() {
+        window?.delegate = nil
+        webView?.navigationDelegate = nil
         window = nil
         webView = nil
     }
 
-    private func completeAuthentication(with result: Result<[String: String], Error>) {
+    private func completeAuthentication(
+        with result: Result<[String: String], Error>,
+        shouldCloseWindow: Bool = true
+    ) {
         assert(Thread.isMainThread, "completeAuthentication must be called from main thread")
         guard !didCompleteAuthentication else { return }
         didCompleteAuthentication = true
@@ -198,13 +224,18 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
             continuation?.resume(throwing: error)
         }
         continuation = nil
-        closeWindowSync()
+        if shouldCloseWindow {
+            closeWindowSync()
+        } else {
+            cleanupWindowReferences()
+        }
     }
 }
 
 // Window delegate to handle window closure
 extension GitHubWebAuthClient: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
-        completeAuthentication(with: .failure(AuthError.userCancelled))
+        isWindowClosing = true
+        completeAuthentication(with: .failure(AuthError.userCancelled), shouldCloseWindow: false)
     }
 }


### PR DESCRIPTION
- Update GitHubCertificatePinner with current SPKI pins for github.com,
  intermediate, and root certificates
- Improve GitHubWebAuthClient window lifecycle: prevent double-close,
  ensure cleanup, and handle user cancellation more robustly
- Show "Security Error" in menu bar if certificate pinning fails
