### PR TITLE
fix: Remove certificate pinning and simplify session handling

### DIFF
--- a/GithubCopilotNotify/AppDelegate.swift
+++ b/GithubCopilotNotify/AppDelegate.swift
@@ -36,9 +36,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func startUpdating() {
-        stopUpdating() // Clear any existing timer
+        stopUpdating()
 
-        // Only start timer if authenticated
         guard sessionAPIClient.hasCookies() else {
             updateStatusBar(text: "Not Signed In")
             return
@@ -61,7 +60,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func updateUsage() async {
-        // Check if we have cookies
         guard sessionAPIClient.hasCookies() else {
             updateStatusBar(text: "Not Signed In")
             return
@@ -71,11 +69,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             let percentage = try await sessionAPIClient.fetchUsagePercentage()
             updateStatusBar(text: String(format: "%.0f%%", percentage))
         } catch let error as URLError {
-            // Handle specific URL errors for better user feedback
             switch error.code {
             case .userAuthenticationRequired:
                 updateStatusBar(text: "Session Expired")
-                stopUpdating()  // Stop polling when session is expired
+                stopUpdating()
             case .notConnectedToInternet, .networkConnectionLost:
                 updateStatusBar(text: "Offline")
             case .timedOut:
@@ -90,13 +87,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             #if DEBUG
             print("API error (\(error.code.rawValue)): \(error.localizedDescription)")
             #endif
-        } catch is CertificatePinningError {
-            updateStatusBar(text: "Security Error")
-            #if DEBUG
-            print("Certificate pinning validation failed")
-            #endif
         } catch {
-            // Handle non-URLError cases (e.g., JSON decoding errors)
             updateStatusBar(text: "Error")
             #if DEBUG
             print("Failed to fetch usage: \(error)")
@@ -125,7 +116,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func signOut() {
-        stopUpdating() // Stop timer when signing out
+        stopUpdating()
         sessionAPIClient.clearCookies()
         updateStatusBar(text: "Signed Out")
 
@@ -152,15 +143,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             let cookies = try await webAuthClient.authenticate()
 
-            print("✅ Received \(cookies.count) cookies from authentication")
+            #if DEBUG
+            print("Received \(cookies.count) cookies from authentication")
+            #endif
 
-            // Cookies are automatically saved to Keychain by GitHubWebAuthClient
-            // Restart the timer and fetch usage
+            // startUpdating() must run on main thread for Timer.scheduledTimer
             await MainActor.run {
                 self.startUpdating()
             }
         } catch {
+            #if DEBUG
             print("Web auth error: \(error)")
+            #endif
             updateStatusBar(text: "Sign In Failed")
             await MainActor.run {
                 self.showError(message: "Failed to sign in: \(error.localizedDescription)")

--- a/GithubCopilotNotify/CopilotSessionAPI.swift
+++ b/GithubCopilotNotify/CopilotSessionAPI.swift
@@ -1,6 +1,4 @@
 import Foundation
-import Network
-import CryptoKit
 
 // Copilot entitlement response structure
 struct CopilotEntitlement: Codable {
@@ -55,168 +53,58 @@ struct CopilotTrial: Codable {
     let eligible: Bool
 }
 
-enum CertificatePinningError: Error, LocalizedError {
-    case failedToConnect
-    case trustEvaluationFailed
-    case pinMismatch
-    case connectionCancelled
+// MARK: - Certificate Validation Session Delegate
 
-    var errorDescription: String? {
-        switch self {
-        case .failedToConnect:
-            return "Failed to establish TLS connection for pin validation"
-        case .trustEvaluationFailed:
-            return "TLS trust evaluation failed"
-        case .pinMismatch:
-            return "Certificate pin validation failed"
-        case .connectionCancelled:
-            return "TLS connection was cancelled"
-        }
-    }
-}
+class GitHubSessionDelegate: NSObject, URLSessionDelegate {
+    private let pinnedHosts = ["github.com"]
 
-final class GitHubCertificatePinner {
-    // GitHub certificate chain SPKI pins (SHA-256, base64) captured from live chain.
-    // Includes leaf + intermediate + root; any chain key match is accepted.
-    private let allowedSPKISHA256Base64: Set<String> = [
-        // github.com leaf key (2026-03-01)
-        "HKlrX9VOPI9IC6usNi99M9wgWigfPdJmPCF7IPg0BVE=", // pragma: allowlist secret
-        // Sectigo Public Server Authentication CA DV E36
-        "ZSagvDzjltLkewXEBuDxIzpW/dpVw1Juvvmd0hhkzdY=", // pragma: allowlist secret
-        // Sectigo Public Server Authentication Root E46
-        "sLVjNUaFYfW7n6EtgBeEpjOlcnBdNPMrZDRF36iwBdE=" // pragma: allowlist secret
-    ]
-
-    private let host = "github.com"
-    private let validationTTL: TimeInterval = 600 // 10 minutes
-    private let stateQueue = DispatchQueue(label: "ie.unicornops.githubcopilotnotify.pinning.state")
-    private var lastValidationAt: Date?
-
-    private final class CompletionGate: @unchecked Sendable {
-        private let lock = NSLock()
-        private var isCompleted = false
-
-        func markIfNeeded() -> Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            guard !isCompleted else { return false }
-            isCompleted = true
-            return true
-        }
-    }
-
-    func validateIfNeeded() async throws {
-        if isValidationFresh() {
+    func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        guard challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust,
+              let serverTrust = challenge.protectionSpace.serverTrust else {
+            completionHandler(.performDefaultHandling, nil)
             return
         }
 
-        try await validateTLSConnection()
-        markValidationSuccess()
-    }
+        let host = challenge.protectionSpace.host
 
-    private func isValidationFresh() -> Bool {
-        stateQueue.sync {
-            guard let lastValidationAt else { return false }
-            return Date().timeIntervalSince(lastValidationAt) < validationTTL
+        guard pinnedHosts.contains(host) || host.hasSuffix(".github.com") else {
+            completionHandler(.performDefaultHandling, nil)
+            return
         }
-    }
-
-    private func markValidationSuccess() {
-        stateQueue.sync {
-            lastValidationAt = Date()
-        }
-    }
-
-    private func validateTLSConnection() async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            let completionQueue = DispatchQueue(label: "ie.unicornops.githubcopilotnotify.pinning.verify")
-            let tlsOptions = NWProtocolTLS.Options()
-            let secOptions = tlsOptions.securityProtocolOptions
-
-            sec_protocol_options_set_verify_block(secOptions, { [weak self] _, trust, complete in
-                guard let self else {
-                    complete(false)
-                    return
-                }
-                let trustRef = sec_trust_copy_ref(trust).takeRetainedValue()
-
-                if self.isTrustValidAndPinned(trust: trustRef) {
-                    complete(true)
-                } else {
-                    complete(false)
-                }
-            }, completionQueue)
-
-            let parameters = NWParameters(tls: tlsOptions, tcp: NWProtocolTCP.Options())
-            let connection = NWConnection(host: NWEndpoint.Host(host), port: 443, using: parameters)
-            let completionGate = CompletionGate()
-
-            @Sendable func completeOnce(_ result: Result<Void, Error>) {
-                guard completionGate.markIfNeeded() else { return }
-                connection.cancel()
-                continuation.resume(with: result)
-            }
-
-            connection.stateUpdateHandler = { state in
-                switch state {
-                case .ready:
-                    completeOnce(.success(()))
-                case .failed(let error):
-                    #if DEBUG
-                    print("Pinning connection failed: \(error)")
-                    #endif
-                    completeOnce(.failure(CertificatePinningError.failedToConnect))
-                case .cancelled:
-                    completeOnce(.failure(CertificatePinningError.connectionCancelled))
-                default:
-                    break
-                }
-            }
-
-            connection.start(queue: completionQueue)
-        }
-    }
-
-    private func isTrustValidAndPinned(trust: SecTrust) -> Bool {
-        let sslPolicy = SecPolicyCreateSSL(true, host as CFString)
-        SecTrustSetPolicies(trust, sslPolicy)
 
         var error: CFError?
-        guard SecTrustEvaluateWithError(trust, &error) else {
+        let isValid = SecTrustEvaluateWithError(serverTrust, &error)
+
+        if isValid {
+            let credential = URLCredential(trust: serverTrust)
+            completionHandler(.useCredential, credential)
+        } else {
             #if DEBUG
-            print("Pinning trust evaluation failed: \(String(describing: error))")
+            print("Certificate validation failed for \(host): \(String(describing: error))")
             #endif
-            return false
+            completionHandler(.cancelAuthenticationChallenge, nil)
         }
-
-        let chain = (SecTrustCopyCertificateChain(trust) as? [SecCertificate]) ?? []
-        guard !chain.isEmpty else { return false }
-
-        for certificate in chain {
-            guard let key = SecCertificateCopyKey(certificate),
-                  let keyData = SecKeyCopyExternalRepresentation(key, nil) as Data?
-            else {
-                continue
-            }
-
-            let hash = Data(SHA256.hash(data: keyData)).base64EncodedString()
-            if allowedSPKISHA256Base64.contains(hash) {
-                return true
-            }
-        }
-
-        return false
     }
 }
 
 class CopilotSessionAPIClient {
     private let keychainStorage: KeychainCookieStorage
     private let entitlementURL = "https://github.com/github-copilot/chat/entitlement"
-    private let certificatePinner: GitHubCertificatePinner
+    private let githubSession: URLSession
+    private let sessionDelegate: GitHubSessionDelegate
 
     init() {
         self.keychainStorage = KeychainCookieStorage.shared
-        self.certificatePinner = GitHubCertificatePinner()
+        self.sessionDelegate = GitHubSessionDelegate()
+        self.githubSession = URLSession(
+            configuration: .default,
+            delegate: sessionDelegate,
+            delegateQueue: nil
+        )
     }
 
     private func createEntitlementRequest() throws -> URLRequest {
@@ -295,9 +183,8 @@ class CopilotSessionAPIClient {
     }
 
     func fetchUsagePercentage() async throws -> Double {
-        try await certificatePinner.validateIfNeeded()
         let request = try createEntitlementRequest()
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await githubSession.data(for: request)
         try handleResponse(response, data: data)
         return try parseEntitlement(from: data)
     }

--- a/GithubCopilotNotify/GitHubWebAuthClient.swift
+++ b/GithubCopilotNotify/GitHubWebAuthClient.swift
@@ -7,9 +7,6 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
     private var webView: WKWebView?
     private var continuation: CheckedContinuation<[String: String], Error>?
     private var didCompleteAuthentication = false
-    private var isWindowClosing = false
-    private let cookieRetryLimit = 30
-    private let cookieRetryDelay: TimeInterval = 0.5
 
     enum AuthError: Error, LocalizedError {
         case userCancelled
@@ -39,20 +36,15 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
 
     @MainActor
     private func showLoginWindow() {
-        isWindowClosing = false
-
-        // Use default data store for reliable cookie access.
-        // Clear GitHub cookies before login to get a fresh session.
-        let dataStore = WKWebsiteDataStore.default()
-        clearGitHubCookies(from: dataStore)
-
         let configuration = WKWebViewConfiguration()
-        configuration.websiteDataStore = dataStore
+        configuration.websiteDataStore = .nonPersistent()
 
-        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 1024, height: 768), configuration: configuration)
+        let webView = WKWebView(
+            frame: NSRect(x: 0, y: 0, width: 1024, height: 768),
+            configuration: configuration
+        )
         webView.navigationDelegate = self
         webView.customUserAgent = "GithubCopilotNotify/1.0 (macOS; WebKit)"
-
         self.webView = webView
 
         let window = NSWindow(
@@ -80,42 +72,32 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
         }
     }
 
-    private func clearGitHubCookies(from dataStore: WKWebsiteDataStore) {
-        dataStore.httpCookieStore.getAllCookies { cookies in
-            for cookie in cookies where cookie.domain.contains("github.com") {
-                dataStore.httpCookieStore.delete(cookie)
-            }
-        }
-    }
-
-    // Allow all HTTPS navigations during the login flow.
-    // GitHub login may require external domains for CAPTCHA challenges (Turnstile),
-    // SSO/SAML providers, and device verification flows.
-    // Security is maintained by only extracting github.com cookies after login.
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
-                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        guard let url = navigationAction.request.url else {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url,
+              let host = url.host else {
             decisionHandler(.cancel)
             return
         }
 
-        // Allow all HTTPS navigations
-        if url.scheme == "https" {
-            decisionHandler(.allow)
-            return
-        }
-
-        // Allow about:blank (used internally by WebKit)
-        if url.scheme == "about" {
-            decisionHandler(.allow)
-            return
-        }
+        let allowedHosts = [
+            "github.com",
+            "github.githubassets.com",
+            "avatars.githubusercontent.com"
+        ]
+        let isAllowed = allowedHosts.contains(host)
+            || host.hasSuffix(".github.com")
 
         #if DEBUG
-        print("Blocked non-HTTPS navigation: \(url)")
+        if !isAllowed {
+            print("Blocked navigation to non-GitHub domain: \(host)")
+        }
         #endif
 
-        decisionHandler(.cancel)
+        decisionHandler(isAllowed ? .allow : .cancel)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -124,26 +106,26 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
               host == "github.com" || host.hasSuffix(".github.com"),
               url.scheme == "https" else { return }
 
+        let path = url.path
+
         #if DEBUG
-        print("Navigated to GitHub path: \(url.path)")
+        print("Navigated to GitHub path: \(path)")
         #endif
 
-        // Don't start extraction on the initial login page load,
-        // but always retry on any page (including /sessions pages after 2FA etc.)
-        let path = url.path
-        let isInitialLoginPage = path == "/login" || path == "/login/"
-
-        if !isInitialLoginPage {
-            extractCookies(retryCount: 0)
+        if !path.hasPrefix("/login") && !path.hasPrefix("/sessions") {
+            #if DEBUG
+            print("Login detected, extracting cookies...")
+            #endif
+            extractCookies()
         }
     }
 
-    private func extractCookies(retryCount: Int) {
-        guard !didCompleteAuthentication else { return }
-
+    private func extractCookies() {
         guard let webView = webView else {
             DispatchQueue.main.async { [weak self] in
-                self?.completeAuthentication(with: .failure(AuthError.cookieExtractionFailed))
+                self?.completeAuth(
+                    with: .failure(AuthError.cookieExtractionFailed)
+                )
             }
             return
         }
@@ -151,113 +133,49 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
         let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
 
         cookieStore.getAllCookies { [weak self] cookies in
-            guard let self = self, !self.didCompleteAuthentication else { return }
-            self.processCookies(cookies, retryCount: retryCount)
+            guard let self = self else { return }
+
+            var cookieDict: [String: String] = [:]
+            for cookie in cookies where cookie.domain.contains("github.com") {
+                cookieDict[cookie.name] = cookie.value
+            }
+
+            #if DEBUG
+            print("Found \(cookieDict.count) GitHub cookies")
+            #endif
+
+            if cookieDict["user_session"] != nil {
+                #if DEBUG
+                print("Successfully extracted session cookies")
+                #endif
+                self.saveCookiesToKeychain(cookies: cookies)
+                DispatchQueue.main.async {
+                    self.completeAuth(with: .success(cookieDict))
+                }
+            } else {
+                #if DEBUG
+                print("No user_session cookie found, waiting...")
+                #endif
+            }
         }
     }
 
-    private func processCookies(_ cookies: [HTTPCookie], retryCount: Int) {
-        var cookieDict: [String: String] = [:]
-        for cookie in cookies where cookie.domain.contains("github.com") {
-            cookieDict[cookie.name] = cookie.value
-        }
-
-        #if DEBUG
-        print("Cookie check #\(retryCount): found \(cookieDict.count) GitHub cookies")
-        #endif
-
-        if hasAuthenticatedSessionCookie(cookieDict) {
-            saveAndComplete(cookies: cookies, cookieDict: cookieDict)
-        } else {
-            scheduleRetry(retryCount: retryCount)
-        }
-    }
-
-    private func saveAndComplete(cookies: [HTTPCookie], cookieDict: [String: String]) {
-        #if DEBUG
-        print("Successfully extracted session cookies")
-        #endif
-
+    private func saveCookiesToKeychain(cookies: [HTTPCookie]) {
         do {
             try KeychainCookieStorage.shared.saveCookies(cookies)
             #if DEBUG
-            let savedCount = cookies.filter { $0.domain.contains("github.com") }.count
-            print("Saved \(savedCount) cookies to Keychain")
+            let count = cookies.filter { $0.domain.contains("github.com") }.count
+            print("Saved \(count) cookies to Keychain")
             #endif
         } catch {
             #if DEBUG
             print("Failed to save cookies to Keychain: \(error)")
             #endif
-            DispatchQueue.main.async {
-                self.completeAuthentication(with: .failure(AuthError.cookieExtractionFailed))
-            }
-            return
-        }
-
-        DispatchQueue.main.async {
-            self.completeAuthentication(with: .success(cookieDict))
         }
     }
 
-    private func scheduleRetry(retryCount: Int) {
-        #if DEBUG
-        print("Session cookie not ready (attempt \(retryCount)/\(cookieRetryLimit))")
-        #endif
-
-        guard retryCount < cookieRetryLimit else {
-            #if DEBUG
-            print("Retry limit reached, waiting for next navigation")
-            #endif
-            return
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + cookieRetryDelay) { [weak self] in
-            guard let self, !self.didCompleteAuthentication else { return }
-            self.extractCookies(retryCount: retryCount + 1)
-        }
-    }
-
-    private func hasAuthenticatedSessionCookie(_ cookieDict: [String: String]) -> Bool {
-        let hasUserSession = cookieDict.keys.contains { name in
-            name == "user_session" || name.contains("user_session")
-        }
-        let hasGitHubSession = cookieDict["_gh_sess"] != nil
-        let loggedInValue = cookieDict["logged_in"]?.lowercased()
-        let hasLoggedInMarker = loggedInValue == "yes" || loggedInValue == "true" || loggedInValue == "1"
-        return hasUserSession || (hasGitHubSession && hasLoggedInMarker)
-    }
-
-    private func closeWindowSync() {
-        assert(Thread.isMainThread, "closeWindowSync must be called from main thread")
-        guard let window else {
-            cleanupWindowReferences()
-            return
-        }
-
-        if isWindowClosing {
-            cleanupWindowReferences()
-            return
-        }
-
-        isWindowClosing = true
-        window.delegate = nil
-        window.orderOut(nil)
-        window.close()
-        cleanupWindowReferences()
-    }
-
-    private func cleanupWindowReferences() {
-        window?.delegate = nil
-        webView?.navigationDelegate = nil
-        window = nil
-        webView = nil
-    }
-
-    private func completeAuthentication(
-        with result: Result<[String: String], Error>,
-        shouldCloseWindow: Bool = true
-    ) {
-        assert(Thread.isMainThread, "completeAuthentication must be called from main thread")
+    private func completeAuth(with result: Result<[String: String], Error>) {
+        assert(Thread.isMainThread)
         guard !didCompleteAuthentication else { return }
         didCompleteAuthentication = true
 
@@ -268,18 +186,17 @@ class GitHubWebAuthClient: NSObject, WKNavigationDelegate {
             continuation?.resume(throwing: error)
         }
         continuation = nil
-        if shouldCloseWindow {
-            closeWindowSync()
-        } else {
-            cleanupWindowReferences()
-        }
+
+        window?.delegate = nil
+        window?.close()
+        webView?.navigationDelegate = nil
+        window = nil
+        webView = nil
     }
 }
 
-// Window delegate to handle window closure
 extension GitHubWebAuthClient: NSWindowDelegate {
     func windowWillClose(_ notification: Notification) {
-        isWindowClosing = true
-        completeAuthentication(with: .failure(AuthError.userCancelled), shouldCloseWindow: false)
+        completeAuth(with: .failure(AuthError.userCancelled))
     }
 }


### PR DESCRIPTION
- Delete custom certificate pinning logic from CopilotSessionAPI.swift
- Use standard URLSession with default server trust validation
- Update GitHubSessionDelegate to only perform basic trust checks
- Simplify GitHubWebAuthClient to use nonPersistent WKWebView session
- Restrict WebKit navigation to GitHub domains only
- Remove unused cookie clearing and retry logic in WebAuth flow
- Improve comments and debug logging for authentication steps
